### PR TITLE
Supporting property fabric forwarding mode anycast-gateway under Inte…

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -46,6 +46,12 @@ encapsulation_dot1q:
   config_set_append: "%s encapsulation dot1q %s"
   default_value: ""
 
+fabric_frwd_anycast:
+  kind: boolean
+  config_get_token_append: '/^fabric forwarding mode anycast-gateway$/'
+  config_set_append: "%s fabric forwarding mode anycast-gateway"
+  default_value: false
+
 feature_lacp:
   kind: boolean
   config_get: "show running | i ^feature"


### PR DESCRIPTION
# Description:

Supporting property fabric forwarding mode anycast-gateway under Interface
# Minitests:

---

rtpfe1@agent-lab11-ws:~/smigopal/feb_interface/cisco-network-node-utils$ ruby tests/test_interface.rb -v -n test_interface_fabric_frwd_anycast -- 10.122.197.125 admin admin
Run options: -v -n test_interface_fabric_frwd_anycast -- --seed 13140

 Running:

Node under test:
- name  - agent-lab11-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

conf : ["interface vlan11"]
conf : [" fabric forwarding anycast-gateway-mac 1223.3445.5668"]
conf : ["interface vlan11", "no fabric forwarding mode anycast-gateway"]
conf : ["interface vlan11", " fabric forwarding mode anycast-gateway"]
conf : ["interface vlan11", "no fabric forwarding mode anycast-gateway"]
conf : ["no fabric forwarding anycast-gateway-mac "]
conf : ["interface vlan11", " fabric forwarding mode anycast-gateway"]
conf : ["feature fabric forwarding"]
conf : ["interface vlan11", " fabric forwarding mode anycast-gateway"]
conf : ["interface ethernet1/1"]
conf : ["interface ethernet1/1", " fabric forwarding mode anycast-gateway"]
TestInterface#test_interface_fabric_frwd_anycast = 10.03 s = .

Finished in 10.028258s, 0.0997 runs/s, 0.5983 assertions/s.

1 runs, 6 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/rtpfe1/smigopal/feb_interface/cisco-network-node-utils/coverage. 669 / 1287 LOC (51.98%) covered.
# Rubocop:

---

rtpfe1@agent-lab11-ws:~/smigopal/feb_interface/cisco-network-node-utils$ rubocop lib/cisco_node_utils/interface.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/feb_interface/cisco-network-node-utils$ rubocop tests/test_interface.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
