### PR TITLE
Adding property - fabric forwarding mode anycast-gateway, to Cisco_Interface

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -46,7 +46,7 @@ encapsulation_dot1q:
   config_set_append: "%s encapsulation dot1q %s"
   default_value: ""
 
-fabric_frwd_anycast:
+fabric_forwarding_anycast_gateway:
   kind: boolean
   config_get_token_append: '/^fabric forwarding mode anycast-gateway$/'
   config_set_append: "%s fabric forwarding mode anycast-gateway"

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -46,6 +46,12 @@ encapsulation_dot1q:
   config_set_append: "%s encapsulation dot1q %s"
   default_value: ""
 
+fabric_frwd_anycast:
+  kind: boolean
+  config_get_token_append: '/^fabric forwarding mode anycast-gateway$/'
+  config_set_append: "%s fabric forwarding mode anycast-gateway"
+  default_value: false
+
 feature_lacp:
   kind: boolean
   config_get: "show running | i ^feature"

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -206,18 +206,18 @@ module Cisco
       FabricpathGlobal.fabricpath_feature_set(fabricpath_set)
     end
 
-    def fabric_frwd_anycast
-      config_get('interface', 'fabric_frwd_anycast', @name)
+    def fabric_forwarding_anycast_gateway
+      config_get('interface', 'fabric_forwarding_anycast_gateway', @name)
     end
 
-    def fabric_frwd_anycast=(state)
+    def fabric_forwarding_anycast_gateway=(state)
       begin
         Feature.fabric_forwarding_enable
         no_cmd = (state ? '' : 'no')
         config_set('interface',
-                   'fabric_frwd_anycast', @name, no_cmd)
+                   'fabric_forwarding_anycast_gateway', @name, no_cmd)
         expected_state = state
-        fail if fabric_frwd_anycast.to_s != expected_state.to_s
+        fail if fabric_forwarding_anycast_gateway.to_s != expected_state.to_s
       end
     rescue Cisco::CliError => e
       vxlan_global = VxlanGlobal.new
@@ -228,8 +228,8 @@ module Cisco
       end
     end
 
-    def default_fabric_frwd_anycast
-      config_get_default('interface', 'fabric_frwd_anycast')
+    def default_fabric_forwarding_anycast_gateway
+      config_get_default('interface', 'fabric_forwarding_anycast_gateway')
     end
 
     def fex_feature

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -959,7 +959,7 @@ class TestInterface < CiscoTestCase
     assert_raises(RuntimeError) { nonvlanint.ipv4_arp_timeout = 300 }
   end
 
-  def test_interface_fabric_frwd_anycast
+  def test_interface_fabric_forwarding_anycast_gateway
     # Setup
     config('no interface vlan11')
     int = Interface.new('vlan11')
@@ -968,28 +968,33 @@ class TestInterface < CiscoTestCase
     foo.anycast_gateway_mac = '1223.3445.5668'
 
     # 1. Testing default
-    int.fabric_frwd_anycast = false
-    assert_equal(int.default_fabric_frwd_anycast, int.fabric_frwd_anycast)
+    int.fabric_forwarding_anycast_gateway = false
+    assert_equal(int.default_fabric_forwarding_anycast_gateway,
+                 int.fabric_forwarding_anycast_gateway)
 
     # 2. Testing non-default
-    int.fabric_frwd_anycast = true
-    assert_equal(true, int.fabric_frwd_anycast)
+    int.fabric_forwarding_anycast_gateway = true
+    assert_equal(true, int.fabric_forwarding_anycast_gateway)
 
     # 3. Setting back to default
-    int.fabric_frwd_anycast = int.default_fabric_frwd_anycast
-    assert_equal(int.default_fabric_frwd_anycast, int.fabric_frwd_anycast)
+    int.fabric_forwarding_anycast_gateway =
+      int.default_fabric_forwarding_anycast_gateway
+    assert_equal(int.default_fabric_forwarding_anycast_gateway,
+                 int.fabric_forwarding_anycast_gateway)
 
     # 4. Removing fabric forwarding anycast gateway mac
     foo.anycast_gateway_mac = foo.default_anycast_gateway_mac
-    assert_raises(RuntimeError) { int.fabric_frwd_anycast = true }
+    assert_raises(RuntimeError) { int.fabric_forwarding_anycast_gateway = true }
 
     # 5. Removing feature fabric forwarding
     config('no feature fabric forwarding')
-    assert_raises(RuntimeError) { int.fabric_frwd_anycast = true }
+    assert_raises(RuntimeError) { int.fabric_forwarding_anycast_gateway = true }
 
     # 6. Attempting to configure on a non-vlan interface
     nonvlanint = create_interface
-    assert_raises(RuntimeError) { nonvlanint.fabric_frwd_anycast = true }
+    assert_raises(RuntimeError) do
+      nonvlanint.fabric_forwarding_anycast_gateway = true
+    end
   end
 
   def test_interface_ipv4_proxy_arp


### PR DESCRIPTION
# Description:

Supporting property fabric forwarding mode anycast-gateway under Interface
# Minitests:

---

rtpfe1@agent-lab11-ws:~/smigopal/feb_interface/cisco-network-node-utils$ ruby tests/test_interface.rb -v -n test_interface_fabric_forwarding_anycast_gateway -- 10.122.197.125 admin admin
Run options: -v -n test_interface_fabric_forwarding_anycast_gateway -- --seed 26306

Running:

Node under test:
- name  - agent-lab11-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

conf : ["interface vlan11"]
conf : [" fabric forwarding anycast-gateway-mac 1223.3445.5668"]
conf : ["interface vlan11", "no fabric forwarding mode anycast-gateway"]
conf : ["interface vlan11", " fabric forwarding mode anycast-gateway"]
conf : ["interface vlan11", "no fabric forwarding mode anycast-gateway"]
conf : ["no fabric forwarding anycast-gateway-mac "]
conf : ["interface vlan11", " fabric forwarding mode anycast-gateway"]
conf : ["feature fabric forwarding"]
conf : ["interface vlan11", " fabric forwarding mode anycast-gateway"]
conf : ["interface ethernet1/1"]
conf : ["interface ethernet1/1", " fabric forwarding mode anycast-gateway"]
TestInterface#test_interface_fabric_forwarding_anycast_gateway = 10.29 s = .

Finished in 10.289229s, 0.0972 runs/s, 0.5831 assertions/s.

1 runs, 6 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/rtpfe1/smigopal/feb_interface/cisco-network-node-utils/coverage. 669 / 1287 LOC (51.98%) covered.
rtpfe1@agent-lab11-ws:~/smigopal/feb_interface/cisco-network-node-utils$
# Rubocop:

---

rtpfe1@agent-lab11-ws:~/smigopal/feb_interface/cisco-network-node-utils$ rubocop tests/test_interface.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/feb_interface/cisco-network-node-utils$ rubocop lib/cisco_node_utils/interface.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/feb_interface/cisco-network-node-utils$
